### PR TITLE
inflate nodelist pattern like host-[001-003]

### DIFF
--- a/nodelist_inflator/nodelist_infate.py
+++ b/nodelist_inflator/nodelist_infate.py
@@ -2,6 +2,12 @@
 import argparse
 import re
 
+def num_string_generator(start, end):
+    assert len(start) == len(end), "length of start and end should be same"
+    assert int(start) < int(end), "start should be less than end"
+    for i in range(int(start), int(end) + 1):
+        yield str(i).zfill(len(start))
+
 # Output the full hostnames
 
 def expand_hostnames(hostnames):
@@ -15,8 +21,8 @@ def expand_hostnames(hostnames):
             range_parts = match[1].strip('[]').split(',')
             for part in range_parts:
                 if '-' in part:
-                    start_range, end_range = map(int,part.split('-'))
-                    for i in range(start_range, end_range + 1):
+                    start_range, end_range = part.split('-')
+                    for i in num_string_generator(start_range, end_range):
                         expanded.append(f"{hostname}{i}")
                 else:
                     expanded.append(f"{hostname}{part}")
@@ -27,7 +33,7 @@ def expand_hostnames(hostnames):
 
 def cli():
     parser = argparse.ArgumentParser(description='Expand hostnames')
-    parser.add_argument("--nodelist", type=str, default="ip-26-0-129-85,ip-26-0-130-171,ip-26-0-137-[14-15,22]", help="List of nodes", required=True)
+    parser.add_argument("--nodelist", type=str, default="ip-26-0-129-85,ip-26-0-130-171,ip-26-0-137-[14-15,22],worker-[001-003]", help="List of nodes", required=True)
     parser.add_argument("--write", action="store_true", help="Write expanded hostnames to a hostname file")
     parser.add_argument("--hostname", type=str, help="Hostname to get rank of")
 
@@ -42,11 +48,11 @@ def cli():
                 break
         else:
             raise Exception(f"Hostname {args.hostname} not found")
-    
+
     if args.write:
         lines = [f"{host} slots=8\n" for host in expanded]
         with open("hostnames", "w") as f:
             f.writelines(lines)
-        
+
 if __name__ == "__main__":
     cli()


### PR DESCRIPTION
Thank you for your work.

In my case, names are 'worker-001', 'worker-002', and so on.

So, worker-[001-003] need to be inflated to ['worker-001', 'worker-002', 'worker-003'].